### PR TITLE
Set content type to header for multipart/form-data

### DIFF
--- a/goclient/testdata/fixture.go_server_methods.go
+++ b/goclient/testdata/fixture.go_server_methods.go
@@ -672,7 +672,7 @@ func (_c Client) TestTypeOverrides(ctx context.Context, body *Primitives, number
 }
 
 // TestUnknownBodyType post /test/unknown/body/type
-func (_c Client) TestUnknownBodyType(ctx context.Context, body io.ReadCloser) (TestUnknownBodyType200Inline, *http.Response, error) {
+func (_c Client) TestUnknownBodyType(ctx context.Context, contentType string, body io.ReadCloser) (TestUnknownBodyType200Inline, *http.Response, error) {
 	var _resp TestUnknownBodyType200Inline
 	var _httpResp *http.Response
 	var _err error
@@ -683,6 +683,7 @@ func (_c Client) TestUnknownBodyType(ctx context.Context, body io.ReadCloser) (T
 		return _resp, _httpResp, _err
 	}
 	_req.Body = body
+	_req.Header.Set("Content-Type", contentType)
 	var _query url.Values
 	if len(_query) > 0 {
 		_req.URL.RawQuery = _query.Encode()

--- a/templates/go/client_methods.tpl
+++ b/templates/go/client_methods.tpl
@@ -28,7 +28,7 @@ func (_c Client) {{$opname}}(ctx context.Context
                     {{- end -}}
             {{- else -}}
                 {{- $.Import "io" -}}
-                , body io.ReadCloser
+                , contentType string, body io.ReadCloser
             {{- end -}}
         {{- end -}}
 		{{- range $param := $op.Parameters -}}
@@ -71,6 +71,7 @@ func (_c Client) {{$opname}}(ctx context.Context
             _req.Body = io.NopCloser(bytes.NewReader(_bodyBytes))
         {{- else}}
             _req.Body = body
+            _req.Header.Set("Content-Type", contentType)
         {{- end -}}
     {{- end -}}
 	{{- range $param := $op.Parameters -}}


### PR DESCRIPTION
# Problem
Currently, we can't use the the client-generated endpoints for testing when the content type is `multipart/form-data`. 
This PR sets the content type when the content type is not `application/json`.
Since we are not testing endpoints with multipart/form-data, it will not be a breaking change. 

# How it should be used

### Template generated:
```go
// PostFundraisingTemplate post /companies/{company_id}/fundraising_templates
func (_c Client) PostFundraisingTemplate(ctx context.Context, body io.ReadCloser, contentType string, companyId int32) (PostFundraisingTemplateResponse, *http.Response, error) {
	var _resp PostFundraisingTemplateResponse
	var _httpResp *http.Response
	var _err error
	baseURL := _c.url
	_urlStr := strings.TrimSuffix(baseURL.ToURL(), "/") + `/companies/{company_id}/fundraising_templates`
	_urlStr = strings.Replace(_urlStr, `{company_id}`, fmt.Sprintf("%v", companyId), 1)
	_req, _err := http.NewRequestWithContext(ctx, http.MethodPost, _urlStr, nil)
	if _err != nil {
		return _resp, _httpResp, _err
	}
	_req.Body = body
	_req.Header.Set("Content-Type", contentType)
	var _query url.Values
	if len(_query) > 0 {
		_req.URL.RawQuery = _query.Encode()
	}

	_httpResp, _err = _c.doRequest(ctx, _req)
	if _err != nil {
		return _resp, _httpResp, _err
	}

	switch _httpResp.StatusCode {
	case 201:
		var _respObject FundraisingTemplate
		_b, _err := io.ReadAll(_httpResp.Body)
		if _err != nil {
			return _resp, _httpResp, _err
		}
		if _err = json.Unmarshal(_b, &_respObject); _err != nil {
			return _resp, _httpResp, _err
		}
		_resp = _respObject
	case 400:
		var _respObject APIError
		_b, _err := io.ReadAll(_httpResp.Body)
		if _err != nil {
			return _resp, _httpResp, _err
		}
		if _err = json.Unmarshal(_b, &_respObject); _err != nil {
			return _resp, _httpResp, _err
		}
		_resp = _respObject
	default:
		return _resp, _httpResp, fmt.Errorf("unknown response code %d", _httpResp.StatusCode)
	}

	return _resp, _httpResp, nil
}
```

### Tests: 

```go
func TestPOSTFundraisingTemplateEndpoint(t *testing.T) {
	require := require.New(t)

	var (
		owner     = loginUser("admin@gmail.com", "1")
		companyID = createCompany(t, owner, t.Name())
	)
	var b bytes.Buffer
	w := multipart.NewWriter(&b)

	const (
		template      = `{"conversion_discount": "10", "mfn": true, "name": "The name", "pro_rata": false, "safe_type": "PRE_MONEY", "valuation_cap": "10000"}`
		requestedDate = "2023-01-02"
	)
	require.NoError(w.WriteField("type", string(sqlc.FundraisingTemplateTypeSAFE)))
	require.NoError(w.WriteField("template", template))
	require.NoError(w.WriteField("fundraising_amount", "12"))
	require.NoError(w.WriteField("date", requestedDate))

	err := w.Close()
	require.NoError(err)

	resp, httpRep, err := v3api.PostFundraisingTemplate(owner.ctx, io.NopCloser(&b), w.FormDataContentType(), companyID)
	require.NoError(err)
	require.Equal(http.StatusCreated, httpRep.StatusCode)
	require.IsType(oa3genclient.FundraisingTemplate{}, resp)
```

