### PR TITLE
Add validator methods for shopspring decimal

### DIFF
--- a/goserver/testdata/fixture.schema_primitives.go
+++ b/goserver/testdata/fixture.schema_primitives.go
@@ -60,9 +60,6 @@ func (o Primitives) validateSchema() support.Errors {
 	if err := support.ValidateMinShopspringDecimal(o.Decimal, decimal.NewFromFloat(5.25), false); err != nil {
 		ers = append(ers, err)
 	}
-	if err := support.ValidateFormatDecimal(o.Decimal); err != nil {
-		ers = append(ers, err)
-	}
 	if len(ers) != 0 {
 		ctx = append(ctx, "decimal")
 		errs = support.AddErrs(errs, strings.Join(ctx, "."), ers...)
@@ -76,9 +73,6 @@ func (o Primitives) validateSchema() support.Errors {
 			ers = append(ers, err)
 		}
 		if err := support.ValidateMinShopspringDecimal(val, decimal.NewFromFloat(5.25), false); err != nil {
-			ers = append(ers, err)
-		}
-		if err := support.ValidateFormatDecimal(val); err != nil {
 			ers = append(ers, err)
 		}
 		if len(ers) != 0 {

--- a/goserver/testdata/fixture.schema_primitives.go
+++ b/goserver/testdata/fixture.schema_primitives.go
@@ -57,6 +57,37 @@ func (o Primitives) validateSchema() support.Errors {
 	_, _, _ = ctx, ers, errs
 
 	ers = nil
+	if err := support.ValidateMinShopspringDecimal(o.Decimal, decimal.NewFromFloat(5.25), false); err != nil {
+		ers = append(ers, err)
+	}
+	if err := support.ValidateFormatDecimal(o.Decimal); err != nil {
+		ers = append(ers, err)
+	}
+	if len(ers) != 0 {
+		ctx = append(ctx, "decimal")
+		errs = support.AddErrs(errs, strings.Join(ctx, "."), ers...)
+		ctx = ctx[:len(ctx)-1]
+	}
+
+	if val, ok := o.DecimalNull.Get(); ok {
+
+		ers = nil
+		if err := support.ValidateMaxShopspringDecimal(val, decimal.NewFromFloat(10.25), false); err != nil {
+			ers = append(ers, err)
+		}
+		if err := support.ValidateMinShopspringDecimal(val, decimal.NewFromFloat(5.25), false); err != nil {
+			ers = append(ers, err)
+		}
+		if err := support.ValidateFormatDecimal(val); err != nil {
+			ers = append(ers, err)
+		}
+		if len(ers) != 0 {
+			ctx = append(ctx, "decimal_null")
+			errs = support.AddErrs(errs, strings.Join(ctx, "."), ers...)
+			ctx = ctx[:len(ctx)-1]
+		}
+	}
+	ers = nil
 	if err := support.ValidateMultipleOfFloat(o.Float, 5.5); err != nil {
 		ers = append(ers, err)
 	}

--- a/goserver/testdata/go_server.yaml
+++ b/goserver/testdata/go_server.yaml
@@ -469,8 +469,8 @@ components:
 
         uuid:          { type: string, format: uuid }
         uuid_null:     { type: string, format: uuid, nullable: true }
-        decimal:       { type: string, format: decimal }
-        decimal_null:  { type: string, format: decimal, nullable: true }
+        decimal:       { type: string, format: decimal, minimum: 5.25}
+        decimal_null:  { type: string, format: decimal, nullable: true, minimum: 5.25, maximum: 10.25}
         time_val:      { type: string, format: time }
         time_null:     { type: string, format: time, nullable: true }
         datetime_val:  { type: string, format: date-time }

--- a/main.go
+++ b/main.go
@@ -98,6 +98,10 @@ func rootCmdRun(cmd *cobra.Command, args []string) error {
 		params[splits[0]] = splits[1]
 	}
 
+	if _, ok := params["decimaltype"]; !ok {
+		params["decimaltype"] = "string"
+	}
+
 	files, err := generate(args[0], args[1], params)
 	if err != nil {
 		return err

--- a/openapi3spec/schema.go
+++ b/openapi3spec/schema.go
@@ -140,6 +140,10 @@ func (s *Schema) Validate() error {
 	}
 	if s.Maximum != nil {
 		switch s.Type {
+		case "string":
+			if (s.Format != nil && *s.Format != "decimal") {
+				return errors.New("maximum: cannot be used unless format is 'decimal'")
+			}
 		case "integer", "number":
 		default:
 			return errors.New("maximum: cannot be used unless type is one of: 'integer', 'number'")
@@ -147,6 +151,10 @@ func (s *Schema) Validate() error {
 	}
 	if s.Minimum != nil {
 		switch s.Type {
+		case "string":
+			if (s.Format != nil && *s.Format != "decimal") {
+				return errors.New("minimum: cannot be used unless format is 'decimal'")
+			}
 		case "integer", "number":
 		default:
 			return errors.New("minimum: cannot be used unless type is one of: 'integer', 'number'")

--- a/support/validation.go
+++ b/support/validation.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"golang.org/x/exp/constraints"
+	"github.com/shopspring/decimal"
 )
 
 var (
@@ -26,7 +27,8 @@ func ValidateFormatUUIDv4(s string) error {
 }
 
 // ValidateFormatDecimal checks it look like it's in a decimal shape
-func ValidateFormatDecimal(s string) error {
+func ValidateFormatDecimal(d decimal.Decimal) error {
+	s := d.String()
 	if !rgxDecimal.MatchString(s) {
 		return errors.New("must be a valid decimal number")
 	}
@@ -57,6 +59,36 @@ func ValidateMinNumber[N constraints.Integer | constraints.Float](val, min N, ex
 		}
 	} else {
 		if val < min {
+			return fmt.Errorf("must be greater than or equal to %v", min)
+		}
+	}
+
+	return nil
+}
+
+// ValidateMaxDecimal checks that val <= max or if exclusive then val < max
+func ValidateMaxShopspringDecimal(val, max decimal.Decimal, exclusive bool) error {
+	if exclusive {
+		if val.GreaterThanOrEqual(max) {
+			return fmt.Errorf("must be less than %v", max)
+		}
+	} else {
+		if val.GreaterThan(max) {
+			return fmt.Errorf("must be less than or equal to %v", max)
+		}
+	}
+
+	return nil
+}
+
+// ValidateMinDecimal checks that val >= min or if exclusive then val > min
+func ValidateMinShopspringDecimal(val, min decimal.Decimal, exclusive bool) error {
+	if exclusive {
+		if val.LessThanOrEqual(min) {
+			return fmt.Errorf("must be greater than %v", min)
+		}
+	} else {
+		if val.LessThan(min) {
 			return fmt.Errorf("must be greater than or equal to %v", min)
 		}
 	}

--- a/support/validation.go
+++ b/support/validation.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/exp/constraints"
 	"github.com/shopspring/decimal"
+	"golang.org/x/exp/constraints"
 )
 
 var (
@@ -27,8 +27,7 @@ func ValidateFormatUUIDv4(s string) error {
 }
 
 // ValidateFormatDecimal checks it look like it's in a decimal shape
-func ValidateFormatDecimal(d decimal.Decimal) error {
-	s := d.String()
+func ValidateFormatDecimal(s string) error {
 	if !rgxDecimal.MatchString(s) {
 		return errors.New("must be a valid decimal number")
 	}

--- a/templates/go/validate_field.tpl
+++ b/templates/go/validate_field.tpl
@@ -11,13 +11,24 @@ if err := support.ValidateMinLength({{$name}}, {{$.Object.MinLength}}); err != n
     ers = append(ers, err)
 }
 {{- end -}}
-{{- if $.Object.Maximum}}
+{{- if and $.Object.Maximum (eq $.Object.Type "number")}}
 if err := support.ValidateMaxNumber({{$name}}, {{$.Object.Maximum}}, {{$.Object.ExclusiveMaximum}}); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}
-{{- if $.Object.Minimum}}
+{{- if and $.Object.Maximum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal")}}
+if err := support.ValidateMaxShopSpringDecimal({{$name}}, decimal.NewFromString({{$.Object.Maximum}})); err != nil {
+    ers = append(ers, err)
+}
+{{- end -}}
+{{- end -}}
+{{- if and $.Object.Minimum (eq $.Object.Type "number")}}
 if err := support.ValidateMinNumber({{$name}}, {{$.Object.Minimum}}, {{$.Object.ExclusiveMinimum}}); err != nil {
+    ers = append(ers, err)
+}
+{{- end -}}
+{{- if and $.Object.Minimum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal")}}
+if err := support.ValidateMinShopSpringDecimal({{$name}}, decimal.NewFromString({{$.Object.Minimum}})); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}

--- a/templates/go/validate_field.tpl
+++ b/templates/go/validate_field.tpl
@@ -16,7 +16,7 @@ if err := support.ValidateMaxNumber({{$name}}, {{$.Object.Maximum}}, {{$.Object.
     ers = append(ers, err)
 }
 {{- end -}}
-{{- if and $.Object.Maximum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal")}}
+{{- if and $.Object.Maximum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal") (eq $.Params.decimaltype "shopspring")}}
 if err := support.ValidateMaxShopspringDecimal({{$name}}, decimal.NewFromFloat({{$.Object.Maximum}}), {{$.Object.ExclusiveMaximum}}); err != nil {
     ers = append(ers, err)
 }
@@ -26,7 +26,7 @@ if err := support.ValidateMinNumber({{$name}}, {{$.Object.Minimum}}, {{$.Object.
     ers = append(ers, err)
 }
 {{- end -}}
-{{- if and $.Object.Minimum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal")}}
+{{- if and $.Object.Minimum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal") (eq $.Params.decimaltype "shopspring")}}
 if err := support.ValidateMinShopspringDecimal({{$name}}, decimal.NewFromFloat({{$.Object.Minimum}}), {{$.Object.ExclusiveMinimum}}); err != nil {
     ers = append(ers, err)
 }
@@ -66,7 +66,7 @@ if err := support.ValidateFormatUUIDv4(string({{$name}})); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}
-{{- if and $.Object.Format (eq (printf $.Object.Format) "decimal") }}
+{{- if and $.Object.Format (eq (printf $.Object.Format) "decimal") (eq $.Params.decimaltype "string")}}}
 if err := support.ValidateFormatDecimal({{$name}}); err != nil {
     ers = append(ers, err)
 }

--- a/templates/go/validate_field.tpl
+++ b/templates/go/validate_field.tpl
@@ -11,24 +11,23 @@ if err := support.ValidateMinLength({{$name}}, {{$.Object.MinLength}}); err != n
     ers = append(ers, err)
 }
 {{- end -}}
-{{- if and $.Object.Maximum (eq $.Object.Type "number")}}
+{{- if and $.Object.Maximum (or (eq $.Object.Type "number") (eq $.Object.Type "integer"))}}
 if err := support.ValidateMaxNumber({{$name}}, {{$.Object.Maximum}}, {{$.Object.ExclusiveMaximum}}); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}
 {{- if and $.Object.Maximum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal")}}
-if err := support.ValidateMaxShopSpringDecimal({{$name}}, decimal.NewFromString({{$.Object.Maximum}})); err != nil {
+if err := support.ValidateMaxShopspringDecimal({{$name}}, decimal.NewFromFloat({{$.Object.Maximum}}), {{$.Object.ExclusiveMaximum}}); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}
-{{- end -}}
-{{- if and $.Object.Minimum (eq $.Object.Type "number")}}
+{{- if and $.Object.Minimum (or (eq $.Object.Type "number") (eq $.Object.Type "integer"))}}
 if err := support.ValidateMinNumber({{$name}}, {{$.Object.Minimum}}, {{$.Object.ExclusiveMinimum}}); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}
 {{- if and $.Object.Minimum (eq $.Object.Type "string") (eq (printf $.Object.Format) "decimal")}}
-if err := support.ValidateMinShopSpringDecimal({{$name}}, decimal.NewFromString({{$.Object.Minimum}})); err != nil {
+if err := support.ValidateMinShopspringDecimal({{$name}}, decimal.NewFromFloat({{$.Object.Minimum}}), {{$.Object.ExclusiveMinimum}}); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}


### PR DESCRIPTION
Using a spec like :
```
decimal_number:
    type: string
    format: decimal
    minimum: 0
```

Resulted in this error in the generated go files
![Screenshot 2024-02-29 at 3 23 12 PM](https://github.com/aarondl/oa3/assets/15956660/6aea7e9e-0cfa-4f81-a58e-5cbe5729000d)

This PR adds a new validator function to be used for when the spec uses a type string with a format of decimal.
