### PR TITLE
add .Body to wrapped responses

### DIFF
--- a/goserver/testdata/fixture.go_server_methods.go
+++ b/goserver/testdata/fixture.go_server_methods.go
@@ -1223,7 +1223,7 @@ func (o GoServer) setuserOp(w http.ResponseWriter, r *http.Request) error {
 			headers.Set("X-Response-Header", val)
 		}
 		w.WriteHeader(respBody.Code)
-		if err := support.WriteJSON(w, respBody); err != nil {
+		if err := support.WriteJSON(w, respBody.Body); err != nil {
 			return err
 		}
 	case *SetUserWrappedResponse:
@@ -1232,7 +1232,7 @@ func (o GoServer) setuserOp(w http.ResponseWriter, r *http.Request) error {
 			headers.Set("X-Response-Header", val)
 		}
 		w.WriteHeader(respBody.Code)
-		if err := support.WriteJSON(w, respBody); err != nil {
+		if err := support.WriteJSON(w, respBody.Body); err != nil {
 			return err
 		}
 	default:

--- a/templates/go/api_methods.tpl
+++ b/templates/go/api_methods.tpl
@@ -218,7 +218,7 @@ func (o {{$.Name}}) {{$opname}}Op(w http.ResponseWriter, r *http.Request) error 
                             {{- end -}}
                             {{- if $resp.Content -}}
                             {{- $.Import "github.com/aarondl/oa3/support"}}
-            if err := support.WriteJSON(w, {{$respVar}}); err != nil {
+            if err := support.WriteJSON(w, {{$respVar}}.Body); err != nil {
                 return err
             }
                             {{- end -}}


### PR DESCRIPTION
responses were outputting `{"HeaderSetCookie":"...","Body":{...}}` if they were wrapped (due to being able to output complex responses)

this change just makes it output the Body field of the wrapped responses