### PR TITLE
a stray bracket

### DIFF
--- a/templates/go/validate_field.tpl
+++ b/templates/go/validate_field.tpl
@@ -66,7 +66,7 @@ if err := support.ValidateFormatUUIDv4(string({{$name}})); err != nil {
     ers = append(ers, err)
 }
 {{- end -}}
-{{- if and $.Object.Format (eq (printf $.Object.Format) "decimal") (eq $.Params.decimaltype "string")}}}
+{{- if and $.Object.Format (eq (printf $.Object.Format) "decimal") (eq $.Params.decimaltype "string") }}
 if err := support.ValidateFormatDecimal({{$name}}); err != nil {
     ers = append(ers, err)
 }


### PR DESCRIPTION
example:

```go
func (o Transaction) validateSchema() support.Errors {
    var ctx []string
    var ers []error
    var errs support.Errors
    _, _, _ = ctx, ers, errs

    
ers = nil}
if err := support.ValidateFormatDecimal(o.Amount); err != nil {
    ers = append(ers, err)
}
    if len(ers) != 0 {
        ctx = append(ctx, "amount")
        errs = support.AddErrs(errs, strings.Join(ctx, "."), ers...)
        ctx = ctx[:len(ctx)-1]
    }

    return errs
}
```